### PR TITLE
Fix OrderID empty on cancel order at mundipagg

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mundipagg/ecommerce-module-core",
     "license": "MIT",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "authors":[
         {
             "name":"MundiPagg Embeddables Team",

--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -115,6 +115,10 @@ final class OrderService
     public function cancelAtMundipaggByPlatformOrder(PlatformOrderInterface $platformOrder)
     {
         $orderId = $platformOrder->getMundipaggId();
+        if (empty($orderId)) {
+            return;
+        }
+
         $APIService = new APIService();
 
         $order = $APIService->getOrder($orderId);

--- a/src/Kernel/Services/VersionService.php
+++ b/src/Kernel/Services/VersionService.php
@@ -9,7 +9,7 @@ final class VersionService
 {
     public function getCoreVersion()
     {
-        return '1.2.2';
+        return '1.2.3';
     }
 
     public function getModuleVersion()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Fix OrderID empty on cancel order at mundipagg
| **Why?**          | when it is not a mundipagg order, the code throws an exception
| **How?**          | Verify if the order id is empty, if yes,  to follow the flux