### PR TITLE
Fix invalid directory on scandir

### DIFF
--- a/src/Maintenance/Services/LogInfoRetrieverService.php
+++ b/src/Maintenance/Services/LogInfoRetrieverService.php
@@ -113,6 +113,9 @@ class LogInfoRetrieverService implements InfoRetrieverServiceInterface
     {
         $files = [];
         foreach($dirs as $logDir) {
+            if (!file_exists($logDir)) {
+                continue;
+            }
             $foundFiles = scandir($logDir);
             if ($foundFiles !== false) {
                 foreach ($foundFiles as $foundFile) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-607
| **What?**         | Fix invalid directory on scandir.
| **Why?**          | If directory does not exists on log scan, the core breaks.
| **How?**          | Verify if the directory exists before scanning it.