### PR TITLE
Fix static methods, duplicated configuration and \Throwable issues

### DIFF
--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -97,7 +97,10 @@ abstract class AbstractModuleCoreSetup
             static::$moduleConfig->setStoreId(static::getCurrentStoreId());
         }
 
-        if(static::$moduleConfig->getStoreId() != static::getDefaultStoreId()) {
+        if(
+            static::$moduleConfig->getStoreId() != static::getDefaultStoreId() &&
+            $savedConfig === null
+        ) {
             static::$moduleConfig->setParentConfiguration(self::getDefaultConfigSaved());
             static::$moduleConfig->setInheritAll(true);
             static::$moduleConfig->setId(null);

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -236,7 +236,7 @@ abstract class AbstractModuleCoreSetup
         }
     }
 
-    abstract protected static function setConfig();
+    abstract protected function setConfig();
     abstract public static function loadModuleConfigurationFromPlatform();
     abstract protected static function setModuleVersion();
     abstract protected static function setPlatformVersion();

--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -237,19 +237,19 @@ abstract class AbstractModuleCoreSetup
     }
 
     abstract protected function setConfig();
-    abstract public static function loadModuleConfigurationFromPlatform();
-    abstract protected static function setModuleVersion();
-    abstract protected static function setPlatformVersion();
-    abstract protected static function setLogPath();
+    abstract public function loadModuleConfigurationFromPlatform();
+    abstract protected function setModuleVersion();
+    abstract protected function setPlatformVersion();
+    abstract protected function setLogPath();
     abstract public static function getDatabaseAccessObject();
     /**
      *
      * @return string
      **/
     abstract protected static function getPlatformHubAppPublicAppKey();
-    abstract protected static function _getDashboardLanguage();
-    abstract protected static function _getStoreLanguage();
-    abstract protected static function _formatToCurrency($price);
+    abstract protected function _getDashboardLanguage();
+    abstract protected function _getStoreLanguage();
+    abstract protected function _formatToCurrency($price);
 
     /**
      * @since 1.6.1

--- a/src/Kernel/Abstractions/AbstractPlatformOrderDecorator.php
+++ b/src/Kernel/Abstractions/AbstractPlatformOrderDecorator.php
@@ -8,6 +8,7 @@ use Mundipagg\Core\Kernel\Services\MoneyService;
 use Mundipagg\Core\Kernel\Services\OrderLogService;
 use Mundipagg\Core\Kernel\ValueObjects\OrderState;
 use Mundipagg\Core\Kernel\ValueObjects\OrderStatus;
+use Exception;
 
 abstract class AbstractPlatformOrderDecorator implements PlatformOrderInterface
 {
@@ -40,7 +41,7 @@ abstract class AbstractPlatformOrderDecorator implements PlatformOrderInterface
         $currentStatus = '';
         try {
             $currentStatus = $this->getStatus();
-        }catch(\Throwable $e)
+        }catch(\Exception $e)
         {
         }
 
@@ -63,7 +64,7 @@ abstract class AbstractPlatformOrderDecorator implements PlatformOrderInterface
         $currentState = '';
         try {
             $currentState = $this->getState();
-        }catch(\Throwable $e)
+        }catch(\Exception $e)
         {
 
         }

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -16,6 +16,7 @@ use Mundipagg\Core\Kernel\ValueObjects\Key\PublicKey;
 use Mundipagg\Core\Kernel\ValueObjects\Key\SecretKey;
 use Mundipagg\Core\Kernel\ValueObjects\Key\TestPublicKey;
 use Mundipagg\Core\Kernel\ValueObjects\Key\TestSecretKey;
+use Exception;
 
 class ConfigurationFactory implements FactoryInterface
 {
@@ -193,7 +194,7 @@ class ConfigurationFactory implements FactoryInterface
     {
         try {
             return new TestPublicKey($key);
-        } catch(\Throwable $e) {
+        } catch(\Exception $e) {
         }
 
         return new PublicKey($key);
@@ -203,12 +204,12 @@ class ConfigurationFactory implements FactoryInterface
     {
         try {
             return new TestSecretKey($key);
-        } catch(\Throwable $e) {
+        } catch(\Exception $e) {
         }
 
         try {
             return new SecretKey($key);
-        } catch(\Throwable $e) {
+        } catch(\Exception $e) {
         }
 
         return new HubAccessTokenKey($key);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-671
| **What?**         | Fix static methods, duplicated configuration and \Throwable issues
| **Why?**        | Some methods were declared static and accessed dynamically;
|                   | Configuration table entries were duplicated on bootstrap;
|                   | PHP 5.6 do not recognize \Throwable as a type that could be catch;