### PR TITLE
Fix configuration issues

### DIFF
--- a/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
+++ b/src/Kernel/Abstractions/AbstractModuleCoreSetup.php
@@ -131,9 +131,18 @@ abstract class AbstractModuleCoreSetup
     {
         $configurationRepository = new ConfigurationRepository;
 
-        return $configurationRepository->findByStore(
+        $defaultSavedConfiguration = $configurationRepository->findByStore(
             static::getDefaultStoreId()
         );
+
+        while (
+            $defaultSavedConfiguration !== null &&
+            ($parentId = $defaultSavedConfiguration->getParentId()) !== null
+        ) {
+            $defaultSavedConfiguration = $configurationRepository->find($parentId);
+        }
+
+        return $defaultSavedConfiguration;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-671
| **What?**         | Fix configuration issues
| **Why?**          | If the some platform installation/update routines causes an default value for store_id on configuration table, it will be changed by the default store id, which can cause some issues on loading the default configuration. To avoid it, we only consider an default configuration if it don't have an parent id.