### PR TITLE
Unit tests module core improve circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 commands:
   build:
-    working_directory: /app
     steps:
       - checkout
       - run:
@@ -41,15 +40,8 @@ commands:
           paths:
             - app
 jobs:
-  build-php56:
-    docker:
-      - image: php:5.6-apache
-        environment:
-          APP_ENV: test
-    steps:
-      - build
-
   build-php72:
+    working_directory: /app
     docker:
       - image: php:7.2-apache
         environment:
@@ -58,7 +50,6 @@ jobs:
       - build
 
 workflows:
-  version: 2
   build_publish_deploy:
     jobs:
-      - build
+      - build-php72

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,8 @@
-version: 2
-jobs:
+version: 2.1
+
+commands:
   build:
     working_directory: /app
-    docker:
-      - image: php:7.2-apache
-        environment:
-          APP_ENV: test
     steps:
       - checkout
       - run:
@@ -43,6 +40,23 @@ jobs:
           root: /
           paths:
             - app
+jobs:
+  build-php56:
+    docker:
+      - image: php:5.6-apache
+        environment:
+          APP_ENV: test
+    steps:
+      - build
+
+  build-php72:
+    docker:
+      - image: php:7.2-apache
+        environment:
+          APP_ENV: test
+    steps:
+      - build
+
 workflows:
   version: 2
   build_publish_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,4 +61,5 @@ jobs:
 workflows:
   build_publish_deploy:
     jobs:
+      - build-php56
       - build-php72

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ commands:
           command: |
             docker-php-ext-install pdo
             docker-php-ext-install zip
-            pecl install xdebug-2.6.0
-            docker-php-ext-enable xdebug
+#            pecl install xdebug-2.6.0
+#            docker-php-ext-enable xdebug
       - run:
           name: Display PHP information
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,15 @@ commands:
           paths:
             - app
 jobs:
+  build-php56:
+    working_directory: /app
+    docker:
+      - image: php:5.6-apache
+        environment:
+          APP_ENV: test
+    steps:
+      - build
+
   build-php72:
     working_directory: /app
     docker:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Change config.yml CircleCI to run php7.2 and php5.6.
| **Why?**          | Because some clients use php5.6
| **How?**          | Change config.yml/CircleCI to cretate two jobs and using the same steps.

