### PR TITLE
Fix send of cycles with empty value

### DIFF
--- a/src/Recurrence/Services/SubscriptionService.php
+++ b/src/Recurrence/Services/SubscriptionService.php
@@ -178,7 +178,10 @@ final class SubscriptionService
                 $subProduct->setSelectedRepetition($item->getSelectedOption());
             }
 
-            $subProduct->setCycles($cycles);
+            if (!empty($cycles)) {
+                $subProduct->setCycles($cycles);
+            }
+
             $subProduct->setDescription($item->getDescription());
             $subProduct->setQuantity($item->getQuantity());
             $pricingScheme = PricingScheme::UNIT($item->getAmount());


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-906
| **What?**         | Fix send of cycles with an empty value
| **Why?**          | Because the API only accept values greater than 0
| **How?**          | If is an empty cycle value, we've remove this attribute from the request
