### PR TITLE
Voucher holder document number

### DIFF
--- a/src/Payment/Aggregates/Payments/NewVoucherPayment.php
+++ b/src/Payment/Aggregates/Payments/NewVoucherPayment.php
@@ -8,6 +8,7 @@ use Mundipagg\Core\Kernel\Exceptions\InvalidParamException;
 use Mundipagg\Core\Payment\ValueObjects\AbstractCardIdentifier;
 use Mundipagg\Core\Payment\ValueObjects\CardToken;
 use Mundipagg\Core\Payment\ValueObjects\PaymentMethod;
+use MundiAPILib\Models\CreateCardRequest;
 
 final class NewVoucherPayment extends AbstractCreditCardPayment
 {
@@ -76,13 +77,15 @@ final class NewVoucherPayment extends AbstractCreditCardPayment
     protected function convertToPrimitivePaymentRequest()
     {
         $paymentRequest = parent::convertToPrimitivePaymentRequest();
+        $paymentRequest->card = new CreateCardRequest();
 
+        $paymentRequest->card->holderDocument = $this->getCustomer()->getDocument();
         $paymentRequest->cardToken = $this->getIdentifier()->getValue();
 
         return $paymentRequest;
     }
 
-    static public function getBaseCode()
+    public static function getBaseCode()
     {
         return PaymentMethod::voucher()->getMethod();
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-1064
| **What?**         | Fixes bug, now adds holder document number when will create Voucher order.
| **Why?**          | It's a requirement from Mundipagg API