### PR TITLE
Create Magento's order even with failed payments

### DIFF
--- a/src/Kernel/Abstractions/AbstractEntity.php
+++ b/src/Kernel/Abstractions/AbstractEntity.php
@@ -49,7 +49,7 @@ abstract class AbstractEntity implements JsonSerializable
 
     /**
      *
-     * @return Mundipagg\Core\Kernel\ValueObjects\AbstractValidString
+     * @return \Mundipagg\Core\Kernel\ValueObjects\AbstractValidString
      */
     public function getMundipaggId()
     {

--- a/src/Kernel/Aggregates/Charge.php
+++ b/src/Kernel/Aggregates/Charge.php
@@ -123,7 +123,7 @@ final class Charge extends AbstractEntity implements ChargeInterface
             $this->setRefundedAmount($amountRefunded);
 
             //if all the paid amount was canceled, the charge should be canceled.
-            if ($amount === $this->paidAmount) {
+            if ($amount == $this->paidAmount) {
                 $this->status = ChargeStatus::canceled();
             }
 

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -404,7 +404,7 @@ final class Configuration extends AbstractEntity
     /**
      * @return bool
      */
-    public function isCreateOrderEnabled()
+    protected function isCreateOrderEnabled()
     {
         return $this->createOrderEnabled;
     }

--- a/src/Kernel/Aggregates/Configuration.php
+++ b/src/Kernel/Aggregates/Configuration.php
@@ -134,6 +134,11 @@ final class Configuration extends AbstractEntity
      */
     private $sendMailEnabled;
 
+    /**
+     * @var bool
+     */
+    private $createOrderEnabled;
+
     /** @var VoucherConfig */
     private $voucherConfig;
 
@@ -330,6 +335,19 @@ final class Configuration extends AbstractEntity
     }
 
     /**
+     * @param $createOrderEnabled
+     * @return $this
+     */
+    public function setCreateOrderEnabled($createOrderEnabled)
+    {
+        $this->createOrderEnabled = filter_var(
+            $createOrderEnabled,
+            FILTER_VALIDATE_BOOLEAN
+        );
+        return $this;
+    }
+
+    /**
      *
      * @param  bool $twoCreditCardsEnabled
      * @return Configuration
@@ -381,6 +399,14 @@ final class Configuration extends AbstractEntity
     public function isSendMailEnabled()
     {
         return $this->sendMailEnabled;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCreateOrderEnabled()
+    {
+        return $this->createOrderEnabled;
     }
 
     /**
@@ -676,6 +702,7 @@ final class Configuration extends AbstractEntity
             "inheritAll" => $this->isInheritedAll(),
             "recurrenceConfig" => $this->getRecurrenceConfig(),
             "sendMail" => $this->isSendMailEnabled(),
+            "createOrder" => $this->isCreateOrderEnabled(),
             "voucherConfig" => $this->getVoucherConfig(),
             "debitConfig" => $this->getDebitConfig()
         ];

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -87,6 +87,7 @@ class ConfigurationFactory implements FactoryInterface
         $config->setCreditCardEnabled($data->creditCardEnabled);
         $config->setBoletoCreditCardEnabled($data->boletoCreditCardEnabled);
         $config->setTwoCreditCardsEnabled($data->twoCreditCardsEnabled);
+        $config->setCreateOrderEnabled($data->createOrder);
 
         if (!empty($data->sendMail)) {
             $config->setSendMailEnabled($data->sendMail);

--- a/src/Kernel/Factories/ConfigurationFactory.php
+++ b/src/Kernel/Factories/ConfigurationFactory.php
@@ -87,6 +87,10 @@ class ConfigurationFactory implements FactoryInterface
         $config->setCreditCardEnabled($data->creditCardEnabled);
         $config->setBoletoCreditCardEnabled($data->boletoCreditCardEnabled);
         $config->setTwoCreditCardsEnabled($data->twoCreditCardsEnabled);
+
+        if (empty($data->createOrder)){
+            $data->createOrder = false;
+        }
         $config->setCreateOrderEnabled($data->createOrder);
 
         if (!empty($data->sendMail)) {

--- a/src/Kernel/Services/ChargeService.php
+++ b/src/Kernel/Services/ChargeService.php
@@ -250,7 +250,8 @@ class ChargeService
             $listCharge,
             function (Charge $charge) {
                 return (
-                    ($charge->getStatus()->getStatus() == 'failed')
+                    ($charge->getStatus()->getStatus() == 'failed') ||
+                    ($charge->getStatus()->getStatus() == 'canceled')
                 );
             }
         );
@@ -364,6 +365,7 @@ class ChargeService
     public function save(Charge $charge)
     {
         $chargeRepository = new ChargeRepository();
+
         try {
             $chargeRepository->save($charge);
         } catch (Exception $exception) {

--- a/src/Kernel/Services/ChargeService.php
+++ b/src/Kernel/Services/ChargeService.php
@@ -250,8 +250,7 @@ class ChargeService
             $listCharge,
             function (Charge $charge) {
                 return (
-                    ($charge->getStatus()->getStatus() == 'failed') ||
-                    ($charge->getStatus()->getStatus() == 'canceled')
+                    ($charge->getStatus()->getStatus() == 'failed')
                 );
             }
         );

--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -197,6 +197,7 @@ final class OrderService
             $apiService = new APIService();
             $response = $apiService->createOrder($order);
 
+            $originalResponse = $response;
             $forceCreateOrder = MPSetup::getModuleConfiguration()->isCreateOrderEnabled();
 
             if (!$this->checkResponseStatus($response)) {
@@ -220,6 +221,10 @@ final class OrderService
             $handler->handle($response, $order);
 
             $platformOrder->save();
+
+            if ($forceCreateOrder && !$this->checkResponseStatus($originalResponse)) {
+                throw new \Exception("Can't create order.", 400);
+            }
 
             return [$response];
         } catch (\Exception $e) {

--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -197,13 +197,16 @@ final class OrderService
             $apiService = new APIService();
             $response = $apiService->createOrder($order);
 
-            if (!$this->checkResponseStatus($response)) {
-                $this->persistListChargeFailed($response);
+            $forceCreateOrder = MPSetup::getModuleConfiguration()->isCreateOrderEnabled();
 
+            if (!$this->checkResponseStatus($response)) {
                 $i18n = new LocalizationService();
                 $message = $i18n->getDashboard("Can't create order.");
 
-                throw new \Exception($message, 400);
+                if (!$forceCreateOrder) {
+                    $this->persistListChargeFailed($response);
+                    throw new \Exception($message, 400);
+                }
             }
 
             $platformOrder->save();
@@ -355,5 +358,14 @@ final class OrderService
     public function getOrderByMundiPaggId(OrderId $orderId)
     {
         return $this->orderRepository->findByMundipaggId($orderId);
+    }
+
+    /**
+     * @param string $platformOrderID
+     * @return Order|null
+     */
+    public function getOrderByPlatformId($platformOrderID)
+    {
+        return $this->orderRepository->findByPlatformId($platformOrderID);
     }
 }

--- a/src/Kernel/ValueObjects/Id/OrderId.php
+++ b/src/Kernel/ValueObjects/Id/OrderId.php
@@ -6,6 +6,16 @@ use Mundipagg\Core\Kernel\ValueObjects\AbstractValidString;
 
 class OrderId extends AbstractValidString
 {
+    /**
+     * OrderId string constructor.
+     * @param $orderId
+     * @throws \Mundipagg\Core\Kernel\Exceptions\InvalidParamException
+     */
+    public function __construct($orderId)
+    {
+        parent::__construct($orderId);
+    }
+
     protected function validateValue($value)
     {
         return preg_match('/^or_\w{16}$/', $value) === 1;

--- a/src/Recurrence/Services/SubscriptionService.php
+++ b/src/Recurrence/Services/SubscriptionService.php
@@ -79,9 +79,7 @@ final class SubscriptionService
                 $i18n = new LocalizationService();
                 $message = $i18n->getDashboard("Can't create order.");
 
-                if (!$forceCreateOrder) {
-                    throw new \Exception($message, 400);
-                }
+                throw new \Exception($message, 400);
             }
 
             $this->getSubscriptionMissingData($subscriptionResponse, $subscription);
@@ -102,7 +100,9 @@ final class SubscriptionService
                 $i18n = new LocalizationService();
                 $message = $i18n->getDashboard("Can't create order.");
 
-                throw new \Exception($message, 400);
+                if (!$forceCreateOrder) {
+                    throw new \Exception($message, 400);
+                }
             }
 
             $platformOrder->save();

--- a/src/Recurrence/Services/SubscriptionService.php
+++ b/src/Recurrence/Services/SubscriptionService.php
@@ -73,11 +73,15 @@ final class SubscriptionService
             //Send through the APIService to mundipagg
             $subscriptionResponse = $this->apiService->createSubscription($subscription);
 
+            $forceCreateOrder = MPSetup::getModuleConfiguration()->isCreateOrderEnabled();
+
             if ($subscriptionResponse === null) {
                 $i18n = new LocalizationService();
                 $message = $i18n->getDashboard("Can't create order.");
 
-                throw new \Exception($message, 400);
+                if (!$forceCreateOrder) {
+                    throw new \Exception($message, 400);
+                }
             }
 
             $this->getSubscriptionMissingData($subscriptionResponse, $subscription);

--- a/src/Recurrence/Services/SubscriptionService.php
+++ b/src/Recurrence/Services/SubscriptionService.php
@@ -73,6 +73,7 @@ final class SubscriptionService
             //Send through the APIService to mundipagg
             $subscriptionResponse = $this->apiService->createSubscription($subscription);
 
+            $originalSubscriptionResponse = $subscriptionResponse;
             $forceCreateOrder = MPSetup::getModuleConfiguration()->isCreateOrderEnabled();
 
             if ($subscriptionResponse === null) {
@@ -114,6 +115,13 @@ final class SubscriptionService
             $handler = $this->getResponseHandler($response);
             $handler->handle($response);
             $platformOrder->save();
+
+            if (
+                $forceCreateOrder &&
+                !$this->checkResponseStatus($originalSubscriptionResponse)
+            ) {
+                throw new \Exception("Can't create order.", 400);
+            }
 
             return [$response];
 

--- a/src/Webhook/Services/ChargeHandlerService.php
+++ b/src/Webhook/Services/ChargeHandlerService.php
@@ -88,7 +88,7 @@ final class ChargeHandlerService
 
         $listResponse = [];
         foreach ($chargeListPaid as $charge) {
-            $listResponse[] = $chargeService->cancelJustAtMundiPagg($charge);
+            $listResponse[] = ($chargeService->cancelJustAtMundiPagg($charge))->getMessage();
         }
 
         return $listResponse;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/CONECT-1087
| **What?**         | Creates order and subscription independent the status, based on configuration.
| **Why?**          |Some customers wish to save all order creation attempts, successful or not
| **How?**          | Will be based on configuration, so as not to break the customers who do not want this feature
