### PR TITLE
Avoid cancel order after status closed

### DIFF
--- a/src/Kernel/Services/ChargeService.php
+++ b/src/Kernel/Services/ChargeService.php
@@ -207,7 +207,9 @@ class ChargeService
                 $this->logService->info("Change Order status");
 
                 $order->setStatus(OrderStatus::canceled());
-                $order->getPlatformOrder()->setState(OrderState::canceled());
+                if (!$order->getPlatformOrder()->getState()->equals(OrderState::closed())) {
+                    $order->getPlatformOrder()->setState(OrderState::canceled());
+                }
                 $order->getPlatformOrder()->save();
 
                 $orderRepository->save($order);

--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -71,10 +71,9 @@ final class OrderService
         }
 
         //@todo In the future create a core status machine with the platform
-//        if (!$order->getPlatformOrder()->getState()->equals(OrderState::closed())) {
-//            $platformOrder->setStatus($orderStatus);
-//        }
-        $platformOrder->setStatus($orderStatus);
+        if (!$order->getPlatformOrder()->getState()->equals(OrderState::closed())) {
+            $platformOrder->setStatus($orderStatus);
+        }
 
         $platformOrder->save();
     }

--- a/src/Webhook/Services/OrderHandlerService.php
+++ b/src/Webhook/Services/OrderHandlerService.php
@@ -81,13 +81,10 @@ final class OrderHandlerService extends AbstractHandlerService
         $invoiceService = new InvoiceService();
         $invoiceService->cancelInvoicesFor($order);
 
-//        $order->setStatus(OrderStatus::canceled());
-//        if (!$order->getPlatformOrder()->getState()->equals(OrderState::closed())) {
-//            $order->getPlatformOrder()->setState(OrderState::canceled());
-//        }
-
         $order->setStatus(OrderStatus::canceled());
-        $order->getPlatformOrder()->setState(OrderState::canceled());
+        if (!$order->getPlatformOrder()->getState()->equals(OrderState::closed())) {
+            $order->getPlatformOrder()->setState(OrderState::canceled());
+        }
 
         $orderRepository = new OrderRepository();
         $orderRepository->save($order);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/CONECT-1116
| **What?**         | Avoid canceling the order after status closed
| **Why?**          | Can't back the status canceled after the closed order 
| **How?**          | Verify the order status before change to canceled