### PR TITLE
Avoid to change order status on charge services

### DIFF
--- a/src/Kernel/Services/ChargeService.php
+++ b/src/Kernel/Services/ChargeService.php
@@ -187,7 +187,7 @@ class ChargeService
             $order->getPlatformOrder()->addHistoryComment($history);
 
             $this->logService->info("Synchronizing with platform Order");
-            $orderService->syncPlatformWith($orde, false);
+            $orderService->syncPlatformWith($order, false);
 
             $platformOrderGrandTotal = $moneyService->floatToCents(
                 $platformOrder->getGrandTotal()

--- a/src/Kernel/Services/ChargeService.php
+++ b/src/Kernel/Services/ChargeService.php
@@ -112,7 +112,7 @@ class ChargeService
             $platformOrder->addHistoryComment($history);
 
             $this->logService->info("Synchronizing with platform Order");
-            $orderService->syncPlatformWith($order);
+            $orderService->syncPlatformWith($order, false);
 
             $this->logService->info("Change Order status");
             $order->setStatus(OrderStatus::paid());
@@ -187,7 +187,7 @@ class ChargeService
             $order->getPlatformOrder()->addHistoryComment($history);
 
             $this->logService->info("Synchronizing with platform Order");
-            $orderService->syncPlatformWith($order);
+            $orderService->syncPlatformWith($orde, false);
 
             $platformOrderGrandTotal = $moneyService->floatToCents(
                 $platformOrder->getGrandTotal()
@@ -213,7 +213,7 @@ class ChargeService
                 $order->getPlatformOrder()->save();
 
                 $orderRepository->save($order);
-                $orderService->syncPlatformWith($order);
+                $orderService->syncPlatformWith($order, false);
 
                 $statusOrderLabel = $platformOrder->getStatusLabel(
                     $order->getStatus()

--- a/src/Kernel/Services/OrderService.php
+++ b/src/Kernel/Services/OrderService.php
@@ -38,8 +38,9 @@ final class OrderService
     /**
      *
      * @param Order $order
+     * @param bool $changeStatus
      */
-    public function syncPlatformWith(Order $order)
+    public function syncPlatformWith(Order $order, $changeStatus = true)
     {
         $moneyService = new MoneyService();
 
@@ -65,6 +66,16 @@ final class OrderService
         $platformOrder->setTotalRefunded($refundedAmount);
         $platformOrder->setBaseTotalRefunded($refundedAmount);
 
+        if ($changeStatus) {
+            $this->changeOrderStatus($order);
+        }
+
+        $platformOrder->save();
+    }
+
+    public function changeOrderStatus(Order $order)
+    {
+        $platformOrder = $order->getPlatformOrder();
         $orderStatus = $order->getStatus();
         if ($orderStatus->equals(OrderStatus::paid())) {
             $orderStatus = OrderStatus::processing();
@@ -74,10 +85,7 @@ final class OrderService
         if (!$order->getPlatformOrder()->getState()->equals(OrderState::closed())) {
             $platformOrder->setStatus($orderStatus);
         }
-
-        $platformOrder->save();
     }
-
     public function updateAcquirerData(Order $order)
     {
         $dataServiceClass =

--- a/src/Recurrence/Services/ResponseHandlers/ChargeHandler.php
+++ b/src/Recurrence/Services/ResponseHandlers/ChargeHandler.php
@@ -58,7 +58,7 @@ final class ChargeHandler extends AbstractResponseHandler
         $history = $this->prepareHistoryComment($charge);
         $order->addHistoryComment($history);
 
-        $orderService->syncPlatformWith($order);
+        $orderService->syncPlatformWith($order, false);
 
         $order->save();
     }

--- a/src/Webhook/Services/ChargeOrderService.php
+++ b/src/Webhook/Services/ChargeOrderService.php
@@ -87,7 +87,7 @@ final class ChargeOrderService extends AbstractHandlerService
         $history = $this->prepareHistoryComment($charge);
         $this->order->getPlatformOrder()->addHistoryComment($history);
 
-        $orderService->syncPlatformWith($order);
+        $orderService->syncPlatformWith($order, false);
 
         $this->addWebHookReceivedHistory($webhook);
         $platformOrder->save();
@@ -143,7 +143,7 @@ final class ChargeOrderService extends AbstractHandlerService
         $orderRepository->save($order);
         $history = $this->prepareHistoryComment($charge);
         $order->getPlatformOrder()->addHistoryComment($history);
-        $orderService->syncPlatformWith($order);
+        $orderService->syncPlatformWith($order, false);
 
         $returnMessage = $this->prepareReturnMessage($charge);
 
@@ -214,7 +214,7 @@ final class ChargeOrderService extends AbstractHandlerService
         $orderRepository->save($order);
         $history = $this->prepareHistoryComment($charge);
         $order->getPlatformOrder()->addHistoryComment($history);
-        $orderService->syncPlatformWith($order);
+        $orderService->syncPlatformWith($order, false);
 
         $returnMessage = $this->prepareReturnMessage($charge);
 
@@ -275,7 +275,7 @@ final class ChargeOrderService extends AbstractHandlerService
         $orderRepository->save($order);
         $history = $this->prepareHistoryComment($charge);
         $order->getPlatformOrder()->addHistoryComment($history, false);
-        $orderService->syncPlatformWith($order);
+        $orderService->syncPlatformWith($order, false);
 
         $returnMessage = $this->prepareReturnMessage($charge);
 

--- a/src/Webhook/Services/ChargeRecurrenceService.php
+++ b/src/Webhook/Services/ChargeRecurrenceService.php
@@ -111,7 +111,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         );
         $realOrder->addCharge($charge);
 
-        $orderService->syncPlatformWith($realOrder);
+        $orderService->syncPlatformWith($realOrder, false);
 
         $platformOrder->save();
 
@@ -177,7 +177,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         );
         $realOrder->addCharge($charge);
 
-        $orderService->syncPlatformWith($realOrder);
+        $orderService->syncPlatformWith($realOrder, false);
 
         $returnMessage = $this->prepareReturnMessage($charge);
         $result = [
@@ -252,7 +252,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         );
         $realOrder->addCharge($charge);
 
-        $orderService->syncPlatformWith($realOrder);
+        $orderService->syncPlatformWith($realOrder, false);
 
         $returnMessage = $this->prepareReturnMessage($charge);
         $result = [
@@ -353,7 +353,7 @@ final class ChargeRecurrenceService extends AbstractHandlerService
         );
 
         $realOrder->addCharge($charge);
-        $this->orderService->syncPlatformWith($realOrder);
+        $this->orderService->syncPlatformWith($realOrder, false);
 
         $sender = $this->sendBoletoEmail($charge, $realOrder->getCode(), $platformOrder);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/CONECT-1168
| **What?**         | The order status was changed by charge paid webhook
| **Why?**          | To avoid change order status on charge services
| **How?**          | Only call the change order status method on order services