### PR TITLE
Adds pendingReview and analyzing as new valid statuses for transactions

### DIFF
--- a/src/Kernel/ValueObjects/TransactionStatus.php
+++ b/src/Kernel/ValueObjects/TransactionStatus.php
@@ -24,10 +24,12 @@ final class TransactionStatus extends AbstractValueObject
     const WAITING_PAYMENT = 'waiting_payment';
     const PENDING_REFUND = 'pending_refund';
     const EXPIRED = 'expired';
+    const PENDING_REVIEW = 'pending_review';
+    const ANALYZING = 'analyzing';
 
     /**
      *
-     * @var string 
+     * @var string
      */
     private $status;
 
@@ -124,6 +126,16 @@ final class TransactionStatus extends AbstractValueObject
     public static function expired()
     {
         return new self(self::EXPIRED);
+    }
+
+    public static function pendingReview()
+    {
+        return new self(self::PENDING_REVIEW);
+    }
+
+    public static function analyzing()
+    {
+        return new self(self::ANALYZING);
     }
 
     /**

--- a/tests/Kernel/ValueObjects/TransactionStatusTest.php
+++ b/tests/Kernel/ValueObjects/TransactionStatusTest.php
@@ -9,31 +9,31 @@ class TransactionStatusTest extends TestCase
 {
     protected $validStatuses = [
         'CAPTURED' => [
-            'method' => 'captured', 
+            'method' => 'captured',
             'value' => "captured"
         ],
         'PARTIAL_CAPTURE' => [
-            'method' => 'partialCapture', 
+            'method' => 'partialCapture',
             'value' => "partial_capture"
         ],
         'AUTHORIZED_PENDING_CAPTURE' => [
-            'method' => 'authorizedPendingCapture', 
+            'method' => 'authorizedPendingCapture',
             'value' => 'authorized_pending_capture'
         ],
         'VOIDED' => [
-            'method' => 'voided', 
+            'method' => 'voided',
             'value' => 'voided'
         ],
         'REFUNDED' => [
-            'method' => 'refunded', 
+            'method' => 'refunded',
             'value' => 'refunded'
         ],
         'PARTIAL_VOID' => [
-            'method' => 'partialVoid', 
+            'method' => 'partialVoid',
             'value' => 'partial_void'
         ],
         'WITH_ERROR' => [
-            'method' => 'withError', 
+            'method' => 'withError',
             'value' => 'withError'
         ],
         'NOT_AUTHORIZED' => [
@@ -41,19 +41,19 @@ class TransactionStatusTest extends TestCase
             'value' => 'notAuthorized'
         ],
         'FAILED' => [
-            'method' => 'failed', 
+            'method' => 'failed',
             'value' => 'failed'
-        ],        
+        ],
         'GENERATED' => [
-            'method' => 'generated', 
+            'method' => 'generated',
             'value' => 'generated'
         ],
         'UNDERPAID' => [
-            'method' => 'underpaid', 
+            'method' => 'underpaid',
             'value' => 'underpaid'
         ],
         'PAID' => [
-            'method' => 'paid', 
+            'method' => 'paid',
             'value' => 'paid'
         ],
         'OVERPAID' => [
@@ -75,6 +75,14 @@ class TransactionStatusTest extends TestCase
         'EXPIRED' => [
             'method' => 'expired',
             'value' => 'expired'
+        ],
+        'PENDING_REVIEW' => [
+            'method' => 'pendingReview',
+            'value' => 'pending_review'
+        ],
+        'ANALYZING' => [
+            'method' => 'analyzing',
+            'value' => 'analyzing'
         ]
     ];
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-110
| **What?**         | Adds pendingReview and analyzing as new valid statuses for transactions
| **Why?**          | Ecommerce-module-core did not accept pendingReview and analyzing as valid transaction methods
| **How?**          | New constants and new methods have been implemented in the transaction status class in the module


#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc


Before update example:

![image](https://user-images.githubusercontent.com/41760474/115415696-806e1e00-a1cd-11eb-854a-cf83b7c338c1.png)

![image](https://user-images.githubusercontent.com/41760474/115415775-8fed6700-a1cd-11eb-9e1d-b678c3b76cdd.png)


The error happened but the order was created in the mundipagg and magento (without charge and transactions).

![image](https://user-images.githubusercontent.com/41760474/115416656-55d09500-a1ce-11eb-9bec-c4f0cf108956.png)


After update example:

Order created successfully with charge and transactions and unit tests running.


![image](https://user-images.githubusercontent.com/41760474/115417418-faeb6d80-a1ce-11eb-8215-886772b1851e.png)



#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
