### PR TITLE
Sanitize customer document

### DIFF
--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -128,7 +128,7 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setDocument($document)
     {
-        $this->document = substr($document, 0, 16);
+        $this->document = $this->formatDocument($document);
 
         if (empty($this->document)) {
 
@@ -240,5 +240,15 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
         $customerRequest->phones = $this->getPhonesToSDK();
 
         return $customerRequest;
+    }
+
+    private function formatDocument($document)
+    {
+        $document = preg_replace(
+            '/[^0-9]/is', '',
+            substr($document, 0, 16)
+        );
+
+        return $document;
     }
 }

--- a/src/Payment/Aggregates/Customer.php
+++ b/src/Payment/Aggregates/Customer.php
@@ -128,7 +128,10 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
      */
     public function setDocument($document)
     {
-        $this->document = $this->formatDocument($document);
+        $this->document = preg_replace(
+            '/[^0-9]/is', '',
+            substr($document, 0, 16)
+        );
 
         if (empty($this->document)) {
 
@@ -240,15 +243,5 @@ final class Customer extends AbstractEntity implements ConvertibleToSDKRequestsI
         $customerRequest->phones = $this->getPhonesToSDK();
 
         return $customerRequest;
-    }
-
-    private function formatDocument($document)
-    {
-        $document = preg_replace(
-            '/[^0-9]/is', '',
-            substr($document, 0, 16)
-        );
-
-        return $document;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-185
| **What?**         | Sanitize customer document to fix invalid request
| **Why?**          | Because the invalid request caused an error when editing a customer or update the credit to the customer's account